### PR TITLE
fixed bug in week overview that shifted timeentries on sundays by +1 …

### DIFF
--- a/frontend/src/components/selectors/WeekSelector-TimeTracking.vue
+++ b/frontend/src/components/selectors/WeekSelector-TimeTracking.vue
@@ -17,11 +17,11 @@ const currentDate = ref(getStartOfWeek(new Date()))
 
 // 📅 Berechne Wochenbeginn (Montag)
 function getStartOfWeek(date) {
-  const d = new Date(date)
-  const day = d.getDay()
-  const diff = d.getDate() - day + (day === 0 ? -6 : 1) // Sonntag = 0 => -6
-  d.setDate(diff)
-  d.setHours(0, 0, 0, 0)
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = (day === 0 ? -6 : 1) - day;
+  d.setUTCDate(d.getUTCDate() + diff);
+  d.setUTCHours(0, 0, 0, 0);
   return d
 }
 


### PR DESCRIPTION
fixed the Bug. Timeentries on Sundays are now displayed in the correct week.
![image](https://github.com/user-attachments/assets/9a6d8a8d-ae04-434a-a41c-bb0f04dbc1ad)
